### PR TITLE
feat:: update task objectives

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,15 +35,21 @@ impl TaskManager {
     /// Gets a specific task by name.
     ///
     /// Returns `None` if the task does not exist.
-    pub fn get_task(&self, name: &str) -> Option<&Vec<String>> {
+    pub fn get_task(&self,  name: &str) ->  Option<&Vec<String>> {
         self.tasks.get(name)
     }
-
+    /// Gets a mutable task by name 
+    pub fn get_mut_task(&mut self,  name: &str) ->  Option<&mut Vec<String>> {
+        self.tasks.get_mut(name)
+    }
     /// Deletes a specific task by name.
     ///
     /// Returns `true` if the task was found and deleted, otherwise `false`.
     pub fn delete_task(&mut self, name: &str) -> bool {
         self.tasks.swap_remove(name).is_some()
+    }
+    pub fn update_task(&mut self, name: &str, objective:Vec<String>)  {
+        self.tasks.insert(name.to_string(),objective );
     }
 
     /// Saves the task manager to a JSON file.

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,25 @@ fn main() {
                 Arg::new("name")
                     .help("Name of the task to delete")
                     .required(true),
-            ),
+            )
+      
+        )
+        .subcommand(
+            Command::new("update").about("updates a specific task").arg(
+                Arg::new("name")
+                    .help("Update objectives of a task")
+                    .required(true),
+            )
+            .arg(
+                    Arg::new("objective_id")
+                        .help(" index of objective you wish to update ")
+                        .required(true)
+                )
+            .arg(
+                    Arg::new("objective_value")
+                        .help("new value of objective ")
+                        .required(true)
+                ),
         )
         .get_matches();
 
@@ -80,6 +98,26 @@ fn main() {
             println!("Task '{}' deleted successfully.", name);
         } else {
             println!("No task found with name '{}'", name);
+        }
+    }
+    else if let Some(matches) = matches.subcommand_matches("update") {
+        let name = matches.get_one::<String>("name").unwrap();
+        let objective_id_str = matches.get_one::<String>("objective_id").unwrap(); 
+        let index = objective_id_str.parse::<usize>().expect("Error: objective_id must be a valid u8");
+        match task_manager.get_mut_task(name) { 
+            Some(task) => { 
+            let new_objective_value =matches.get_one::<String>("objective_value").unwrap();
+        if (index) < task.len() {
+            task[index] = new_objective_value.to_string();
+            println!("Updated Task at '{}': {:?}", index, task);
+        } else {
+            println!("Error: Index {} is out of bounds for Vec at key '{}'", index, name);
+        }
+        task_manager
+                .save_to_file(DATA_FILE)
+                .expect("Failed to save tasks");
+            }
+            None => println!("No task found with name '{}'", name),
         }
     }
 }


### PR DESCRIPTION
 created a functionality that allows users to update their task data, 
As Human mistakes might be inevitable, everyone deserves a second shot at everything in life. We make mistakes with the things that may seem so minute. For instance,  when a user mistakenly writes "wrote" instead of "write" or "buy milk" instead of "buy almond milk". The user may be allergic to cow milk but shared the list with her assistant, and realised her mistake after she sent the list, she shouldn't be doomed to live with her mistake, no one deserves that, hence, this Pull request.